### PR TITLE
Widget Body CSS class with max-height

### DIFF
--- a/src/components/widget/widget.less
+++ b/src/components/widget/widget.less
@@ -78,6 +78,11 @@ mno-widget {
         &.no-padding {
           padding: 0;
         }
+
+        &.large-auto-height {
+          max-height: 450px;
+          overflow-y: auto;
+        }
       }
     }
 


### PR DESCRIPTION
Allows widget to have a responsive height, with a maximum. 
Used for https://github.com/maestrano/mnoe-admin-panel/pull/141
This settings covers a bit more than 11 rows