### PR TITLE
[MNOE-777] Set sort arrow on the left of the table header

### DIFF
--- a/src/components/sortable-table/sortable-table.less
+++ b/src/components/sortable-table/sortable-table.less
@@ -12,8 +12,8 @@ mno-sortable-table {
     .st-sort-descent:after {
       font-family: FontAwesome;
       height: 17px;
-      padding-left: 5px;
-      float: right;
+      margin-right: 5px;
+      float: left;
       font-size: 17px;
     }
 


### PR DESCRIPTION
Placing it on the right would make it hard to see which column is it sorted by